### PR TITLE
feat: Add priority levels to tasks

### DIFF
--- a/src/main/java/babe/command/SetPriorityCommand.java
+++ b/src/main/java/babe/command/SetPriorityCommand.java
@@ -1,0 +1,47 @@
+package babe.command;
+
+import babe.task.Task;
+import babe.task.TaskList;
+import babe.ui.Ui;
+import babe.exception.BabeException;
+
+/**
+ * Command to set the priority level of a task in the task list.
+ */
+public class SetPriorityCommand implements Command {
+    private final int taskIndex;
+    private final int priorityLevel;
+
+    /**
+     * Constructs a SetPriorityCommand to change the priority of a task.
+     *
+     * @param taskIndex The index of the task to modify (0-based)
+     * @param priorityLevel The new priority level to set (1-3)
+     */
+    public SetPriorityCommand(int taskIndex, int priorityLevel) {
+        this.taskIndex = taskIndex;
+        this.priorityLevel = priorityLevel;
+    }
+
+    /**
+     * Executes the command to set the priority of the specified task.
+     * Sets the priority and returns a message indicating the change.
+     *
+     * @param tasks The task list containing the task to modify
+     * @param ui The UI component for formatting messages
+     * @return A string containing the result of setting the priority
+     * @throws BabeException if the task index is invalid
+     */
+    @Override
+    public String execute(TaskList tasks, Ui ui) throws BabeException {
+        try {
+            Task task = tasks.getTask(taskIndex);
+            task.setPriority(Task.Priority.fromLevel(priorityLevel));
+            return ui.getUpdatedPriorityMessage(task);
+        } catch (IndexOutOfBoundsException e) {
+            throw new BabeException("The task number is invalid!");
+        } catch (IllegalArgumentException e) {
+            throw new BabeException("Priority level must be between 1 (High) and 3 (Low)!");
+        }
+    }
+}

--- a/src/main/java/babe/task/Deadline.java
+++ b/src/main/java/babe/task/Deadline.java
@@ -1,3 +1,4 @@
+// Deadline.java
 package babe.task;
 
 import java.time.LocalDateTime;
@@ -22,6 +23,18 @@ public class Deadline extends Task {
     }
 
     /**
+     * Constructs a Deadline task with a description, due date, and priority.
+     *
+     * @param description The description of the deadline task.
+     * @param by The due date and time of the deadline.
+     * @param priority The priority level of the task.
+     */
+    public Deadline(String description, LocalDateTime by, Priority priority) {
+        super(description, priority);
+        this.by = by;
+    }
+
+    /**
      * Constructs a Deadline task with a description, due date, and completion status.
      *
      * @param description The description of the deadline task.
@@ -30,6 +43,19 @@ public class Deadline extends Task {
      */
     public Deadline(String description, LocalDateTime by, boolean isDone) {
         super(description, isDone);
+        this.by = by;
+    }
+
+    /**
+     * Constructs a Deadline task with a description, due date, completion status, and priority.
+     *
+     * @param description The description of the deadline task.
+     * @param by The due date and time of the deadline.
+     * @param isDone Whether the deadline task is completed.
+     * @param priority The priority level of the task.
+     */
+    public Deadline(String description, LocalDateTime by, boolean isDone, Priority priority) {
+        super(description, isDone, priority);
         this.by = by;
     }
 
@@ -63,6 +89,6 @@ public class Deadline extends Task {
      */
     @Override
     public Deadline copy() {
-        return new Deadline(this.description, this.by, this.isDone);
+        return new Deadline(this.description, this.by, this.isDone, this.priority);
     }
 }

--- a/src/main/java/babe/task/Event.java
+++ b/src/main/java/babe/task/Event.java
@@ -15,8 +15,8 @@ public class Event extends Task {
      * Constructs an Event task with a description, start time, and end time.
      *
      * @param description The description of the event.
-     * @param start The start time of the event.
-     * @param end The end time of the event.
+     * @param start       The start time of the event.
+     * @param end         The end time of the event.
      */
     public Event(String description, LocalDateTime start, LocalDateTime end) {
         super(description);
@@ -25,15 +25,44 @@ public class Event extends Task {
     }
 
     /**
+     * Constructs an Event task with a description, start time, end time, and priority.
+     *
+     * @param description The description of the event.
+     * @param start       The start time of the event.
+     * @param end         The end time of the event.
+     * @param priority    The priority level of the task.
+     */
+    public Event(String description, LocalDateTime start, LocalDateTime end, Priority priority) {
+        super(description, priority);
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
      * Constructs an Event task with a description, start time, end time, and completion status.
      *
      * @param description The description of the event.
-     * @param start The start time of the event.
-     * @param end The end time of the event.
-     * @param isDone Whether the event is completed.
+     * @param start       The start time of the event.
+     * @param end         The end time of the event.
+     * @param isDone      Whether the event is completed.
      */
     public Event(String description, LocalDateTime start, LocalDateTime end, boolean isDone) {
         super(description, isDone);
+        this.start = start;
+        this.end = end;
+    }
+
+    /**
+     * Constructs an Event task with a description, start time, end time, completion status, and priority.
+     *
+     * @param description The description of the event.
+     * @param start       The start time of the event.
+     * @param end         The end time of the event.
+     * @param isDone      Whether the event is completed.
+     * @param priority    The priority level of the task.
+     */
+    public Event(String description, LocalDateTime start, LocalDateTime end, boolean isDone, Priority priority) {
+        super(description, isDone, priority);
         this.start = start;
         this.end = end;
     }
@@ -88,6 +117,6 @@ public class Event extends Task {
      */
     @Override
     public Event copy() {
-        return new Event(this.description, this.start, this.end, this.isDone);
+        return new Event(this.description, this.start, this.end, this.isDone, this.priority);
     }
 }

--- a/src/main/java/babe/task/Task.java
+++ b/src/main/java/babe/task/Task.java
@@ -3,23 +3,64 @@ package babe.task;
 public class Task {
     protected String description;
     protected boolean isDone;
+    protected Priority priority;  // Add priority field
+
+    public enum Priority {
+        HIGH(1),
+        MEDIUM(2),
+        LOW(3);
+
+        private final int level;
+
+        Priority(int level) {
+            this.level = level;
+        }
+
+        public int getLevel() {
+            return level;
+        }
+
+        public static Priority fromLevel(int level) {
+            return switch (level) {
+                case 1 -> HIGH;
+                case 2 -> MEDIUM;
+                case 3 -> LOW;
+                default -> throw new IllegalArgumentException("Invalid priority level: " + level);
+            };
+        }
+    }
+
+    public Task(String description) {
+        this.description = description;
+        this.isDone = false;
+        this.priority = Priority.MEDIUM;  // Default priority
+    }
+
+    public Task(String description, boolean isDone) {
+        this.description = description;
+        this.isDone = isDone;
+        this.priority = Priority.MEDIUM;  // Default priority
+    }
 
     /**
      * Creates a new babe.task with the given description
      */
-    public Task(String description) {
+    public Task(String description, Priority priority) {
         this.description = description;
         this.isDone = false;
+        this.priority = priority;
     }
 
     /**
      * Creates a babe.task with the given description and completion status
      * Used when loading tasks from babe.storage
      */
-    public Task(String description, boolean isDone) {
+    public Task(String description, boolean isDone, Priority priority) {
         this.description = description;
         this.isDone = isDone;
+        this.priority = priority;
     }
+
 
     public String getStatusIcon() {
         return (isDone ? "X" : " ");
@@ -49,9 +90,17 @@ public class Task {
         return description;
     }
 
+    public Priority getPriority() {
+        return priority;
+    }
+
+    public void setPriority(Priority priority) {
+        this.priority = priority;
+    }
+
     @Override
     public String toString() {
-        return "[" + this.getStatusIcon() + "] " + this.description;
+        return "[" + this.getStatusIcon() + "][P" + this.priority.getLevel() + "] " + this.description;
     }
 
     /**
@@ -59,6 +108,7 @@ public class Task {
      * Used to prevent external modifications to babe.task data
      */
     public Task copy() {
-        return new Task(this.description, this.isDone);
+        return new Task(this.description, this.isDone, this.priority);
     }
+
 }

--- a/src/main/java/babe/task/Todo.java
+++ b/src/main/java/babe/task/Todo.java
@@ -1,3 +1,4 @@
+// Todo.java
 package babe.task;
 
 public class Todo extends Task {
@@ -12,6 +13,16 @@ public class Todo extends Task {
     }
 
     /**
+     * Constructs a Todo task with a description and priority.
+     *
+     * @param description The description of the to-do task.
+     * @param priority The priority level of the task.
+     */
+    public Todo(String description, Priority priority) {
+        super(description, priority);
+    }
+
+    /**
      * Constructs a Todo task with a description and completion status.
      *
      * @param description The description of the to-do task.
@@ -19,6 +30,17 @@ public class Todo extends Task {
      */
     public Todo(String description, boolean isDone) {
         super(description, isDone);
+    }
+
+    /**
+     * Constructs a Todo task with a description, completion status, and priority.
+     *
+     * @param description The description of the to-do task.
+     * @param isDone Whether the to-do task is completed.
+     * @param priority The priority level of the task.
+     */
+    public Todo(String description, boolean isDone, Priority priority) {
+        super(description, isDone, priority);
     }
 
     @Override
@@ -33,6 +55,6 @@ public class Todo extends Task {
      */
     @Override
     public Todo copy() {
-        return new Todo(this.description, this.isDone);
+        return new Todo(this.description, this.isDone, this.priority);
     }
 }

--- a/src/main/java/babe/ui/Ui.java
+++ b/src/main/java/babe/ui/Ui.java
@@ -124,4 +124,14 @@ public class Ui {
     public String getDivider() {
         return DIVIDER;
     }
+
+    /**
+     * Returns a message indicating that a task's priority has been updated.
+     *
+     * @param task The task whose priority was updated.
+     * @return A formatted string containing the priority update confirmation message.
+     */
+    public String getUpdatedPriorityMessage(Task task) {
+        return String.format("Noted. I've updated the priority of this task:\n  %s", task);
+    }
 }


### PR DESCRIPTION
Implement task prioritization system with three levels (High, Medium, Low):
- Add Priority enum to Task class with levels 1-3
- Update Parser to handle priority input via '/p' flag
- Add SetPriorityCommand for modifying existing task priorities
- Modify Storage to persist priority data
- Update Todo, Deadline, and Event classes with priority support

Example usage:
- Create task with priority: todo Read book /p 1
- Update priority: priority 1 2
- Priority appears in display: [X][P1] Read book

Breaking changes:
- Storage format updated to include priority field
- Existing task constructors require priority parameter
- Task string representation now includes priority level